### PR TITLE
feat(http,td,client): add BasicAuth to WoT TD + default client header

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
     "editor.rulers": [
-        80,120
     ],
     "editor.formatOnSave": true,
 }

--- a/hololinked/client/http/consumed_interactions.py
+++ b/hololinked/client/http/consumed_interactions.py
@@ -1,6 +1,7 @@
 """
 Classes that contain the client logic for the HTTP protocol.
 """
+
 import asyncio
 import threading
 import tornado.httpclient
@@ -10,23 +11,63 @@ from tornado.simple_httpclient import HTTPTimeoutError, HTTPStreamClosedError
 
 from ...utils import get_current_async_loop
 from ...constants import Operations
-from ..abstractions import ConsumedThingAction, ConsumedThingEvent, ConsumedThingProperty, raise_local_exception
-from ...td.interaction_affordance import ActionAffordance, EventAffordance, PropertyAffordance
+from ..abstractions import (
+    ConsumedThingAction,
+    ConsumedThingEvent,
+    ConsumedThingProperty,
+    raise_local_exception,
+)
+from ...td.interaction_affordance import (
+    ActionAffordance,
+    EventAffordance,
+    PropertyAffordance,
+)
 from ...td.forms import Form
 from ...serializers import Serializers
 
+
+class AuthHeaderMixin:
+    def _merge_auth_headers(self, base=None):
+        headers = dict(base or {})
+
+        # Avoid truthiness on ObjectProxy
+        owner = getattr(self, "_owner_inst", None)
+        if owner is None:
+            owner = getattr(self, "owner", None)
+
+        auth = getattr(owner, "_auth_header", None) if owner is not None else None
+
+        # Normalize present header names (case-insensitive)
+        present = {k.lower() for k in headers}
+
+        if auth:
+            if isinstance(auth, dict):
+                # Merge key-by-key if caller stored a header dict
+                for k, v in auth.items():
+                    if k.lower() not in present:
+                        headers[k] = v
+            elif isinstance(auth, str):
+                # Caller stored just the value: "Basic abcd=="
+                if "authorization" not in present:
+                    headers["Authorization"] = auth
+            else:
+                # Ignore unexpected types instead of crashing
+                pass
+
+        return headers
 
 
 class HTTPConsumedAffordanceMixin:
     """Implementation of the protocol client interface for the HTTP protocol."""
 
-    def __init__(self,
-                connect_timeout: int = 60,
-                request_timeout: int = 60,
-                invokation_timeout: int = 5,
-                execution_timeout: int = 5,
-                **kwargs
-            ) -> None:
+    def __init__(
+        self,
+        connect_timeout: int = 60,
+        request_timeout: int = 60,
+        invokation_timeout: int = 5,
+        execution_timeout: int = 5,
+        **kwargs,
+    ) -> None:
         super().__init__()
         self._connect_timeout = connect_timeout
         self._request_timeout = request_timeout
@@ -35,39 +76,43 @@ class HTTPConsumedAffordanceMixin:
         self._sync_http_client = tornado.httpclient.HTTPClient()
         self._async_http_client = tornado.httpclient.AsyncHTTPClient()
 
-    
-    def get_body_from_response(self, 
-                            response: tornado.httpclient.HTTPResponse,
-                            form: Form,   
-                            raise_exception: bool = True
-                            ) -> Any:
+    def get_body_from_response(
+        self,
+        response: tornado.httpclient.HTTPResponse,
+        form: Form,
+        raise_exception: bool = True,
+    ) -> Any:
         if response.code >= 200 and response.code < 300:
             body = response.body
             if not body:
                 return
-            serializer = Serializers.content_types.get(form.contentType or "application/json")
+            serializer = Serializers.content_types.get(
+                form.contentType or "application/json"
+            )
             if serializer is None:
                 raise ValueError(f"Unsupported content type: {form.contentType}")
             body = serializer.loads(body)
-            if isinstance(body, dict) and 'exception' in body and raise_exception:
+            if isinstance(body, dict) and "exception" in body and raise_exception:
                 raise_local_exception(body)
             return body
         raise Exception(f"status code {response.code}")
 
-    def create_http_request(self, form: Form, default_method: str, body: bytes | None = None) -> tornado.httpclient.HTTPRequest:
+    def create_http_request(
+        self, form: Form, default_method: str, body: bytes | None = None
+    ) -> tornado.httpclient.HTTPRequest:
         """Creates an HTTP request for the given form and body."""
         return tornado.httpclient.HTTPRequest(
             form.href,
             method=form.htv_methodName or default_method,
             body=body,
-            headers={"Content-Type": "application/json"},
+            headers=self._merge_auth_headers({"Content-Type": "application/json"}),
             connect_timeout=self._connect_timeout,
             request_timeout=self._request_timeout,
         )
-    
-    def read_reply(self, form: Form, message_id: str, timeout = None):
+
+    def read_reply(self, form: Form, message_id: str, timeout=None):
         """Read the reply for a non-blocking action."""
-        form.href = f'{form.href}?messageID={message_id}&timeout={timeout or self._invokation_timeout}'
+        form.href = f"{form.href}?messageID={message_id}&timeout={timeout or self._invokation_timeout}"
         form.htv_methodName = "GET"
         http_request = self.create_http_request(form, "GET", None)
         try:
@@ -75,35 +120,39 @@ class HTTPConsumedAffordanceMixin:
         except HTTPTimeoutError as ex:
             raise TimeoutError(str(ex)) from None
         return self.get_body_from_response(response, form)
-    
 
-class HTTPAction(ConsumedThingAction, HTTPConsumedAffordanceMixin):
 
-    def __init__(self,
-                resource: ActionAffordance,
-                connect_timeout: int = 60,
-                request_timeout: int = 60,
-                invokation_timeout: int = 5,
-                execution_timeout: int = 5,
-                **kwargs
-            ) -> None:
+class HTTPAction(AuthHeaderMixin, ConsumedThingAction, HTTPConsumedAffordanceMixin):
+    def __init__(
+        self,
+        resource: ActionAffordance,
+        connect_timeout: int = 60,
+        request_timeout: int = 60,
+        invokation_timeout: int = 5,
+        execution_timeout: int = 5,
+        **kwargs,
+    ) -> None:
         ConsumedThingAction.__init__(self=self, resource=resource, **kwargs)
         HTTPConsumedAffordanceMixin.__init__(
-                        self=self,
-                        connect_timeout=connect_timeout,
-                        request_timeout=request_timeout,
-                        invokation_timeout=invokation_timeout,
-                        execution_timeout=execution_timeout,
-                        **kwargs
-                    )
+            self=self,
+            connect_timeout=connect_timeout,
+            request_timeout=request_timeout,
+            invokation_timeout=invokation_timeout,
+            execution_timeout=execution_timeout,
+            **kwargs,
+        )
 
     async def async_call(self, *args, **kwargs):
         form = self._resource.retrieve_form(Operations.invokeaction, None)
         if form is None:
-            raise ValueError(f"No form found for invokeAction operation for {self._resource.name}")
-        if args: 
+            raise ValueError(
+                f"No form found for invokeAction operation for {self._resource.name}"
+            )
+        if args:
             kwargs.update({"__args__": args})
-        serializer = Serializers.content_types.get(form.contentType or "application/json")
+        serializer = Serializers.content_types.get(
+            form.contentType or "application/json"
+        )
         body = serializer.dumps(kwargs)
         http_request = self.create_http_request(form, "POST", body)
         try:
@@ -111,14 +160,18 @@ class HTTPAction(ConsumedThingAction, HTTPConsumedAffordanceMixin):
         except HTTPTimeoutError as ex:
             raise TimeoutError(str(ex)) from None
         return self.get_body_from_response(response, form)
-        
+
     def __call__(self, *args, **kwargs):
         form = self._resource.retrieve_form(Operations.invokeaction, None)
         if form is None:
-            raise ValueError(f"No form found for invokeAction operation for {self._resource.name}")
-        if args: 
+            raise ValueError(
+                f"No form found for invokeAction operation for {self._resource.name}"
+            )
+        if args:
             kwargs.update({"__args__": args})
-        serializer = Serializers.content_types.get(form.contentType or "application/json")
+        serializer = Serializers.content_types.get(
+            form.contentType or "application/json"
+        )
         body = serializer.dumps(kwargs)
         http_request = self.create_http_request(form, "POST", body)
         try:
@@ -126,17 +179,21 @@ class HTTPAction(ConsumedThingAction, HTTPConsumedAffordanceMixin):
         except HTTPTimeoutError as ex:
             raise TimeoutError(str(ex)) from None
         return self.get_body_from_response(response, form)
-    
+
     def oneway(self, *args, **kwargs):
         """Invoke the action without waiting for a response."""
         form = deepcopy(self._resource.retrieve_form(Operations.invokeaction, None))
         if form is None:
-            raise ValueError(f"No form found for invokeAction operation for {self._resource.name}")
-        if args: 
+            raise ValueError(
+                f"No form found for invokeAction operation for {self._resource.name}"
+            )
+        if args:
             kwargs.update({"__args__": args})
-        serializer = Serializers.content_types.get(form.contentType or "application/json")
+        serializer = Serializers.content_types.get(
+            form.contentType or "application/json"
+        )
         body = serializer.dumps(kwargs)
-        form.href = f'{form.href}?oneway=true'
+        form.href = f"{form.href}?oneway=true"
         http_request = self.create_http_request(form, "POST", body)
         try:
             response = self._sync_http_client.fetch(http_request)
@@ -144,71 +201,83 @@ class HTTPAction(ConsumedThingAction, HTTPConsumedAffordanceMixin):
             raise TimeoutError(str(ex)) from None
         # we still do it like this only to ensure our logic is consistent, oneway actions do not expect a body
         return self.get_body_from_response(response, form)
-    
+
     def noblock(self, *args, **kwargs) -> str:
         """Invoke the action in non-blocking mode."""
         form = deepcopy(self._resource.retrieve_form(Operations.invokeaction, None))
         if form is None:
-            raise ValueError(f"No form found for invokeAction operation for {self._resource.name}")
-        if args: 
+            raise ValueError(
+                f"No form found for invokeAction operation for {self._resource.name}"
+            )
+        if args:
             kwargs.update({"__args__": args})
-        serializer = Serializers.content_types.get(form.contentType or "application/json")
+        serializer = Serializers.content_types.get(
+            form.contentType or "application/json"
+        )
         body = serializer.dumps(kwargs)
-        form.href = f'{form.href}?noblock=true'
+        form.href = f"{form.href}?noblock=true"
         http_request = self.create_http_request(form, "POST", body)
         try:
             response = self._sync_http_client.fetch(http_request)
         except HTTPTimeoutError as ex:
             raise TimeoutError(str(ex)) from None
-        assert response.headers.get('X-Message-ID', None) is not None, \
+        assert response.headers.get("X-Message-ID", None) is not None, (
             "The server did not return a message ID for the non-blocking action."
-        message_id = response.headers['X-Message-ID']
+        )
+        message_id = response.headers["X-Message-ID"]
         self._owner_inst._noblock_messages[message_id] = self
         return message_id
-    
-    def read_reply(self, message_id, timeout = None):
+
+    def read_reply(self, message_id, timeout=None):
         form = deepcopy(self._resource.retrieve_form(Operations.invokeaction, None))
         if form is None:
-            raise ValueError(f"No form found for invokeAction operation for {self._resource.name}")
+            raise ValueError(
+                f"No form found for invokeAction operation for {self._resource.name}"
+            )
         return HTTPConsumedAffordanceMixin.read_reply(self, form, message_id, timeout)
 
-    
-        
-class HTTPProperty(ConsumedThingProperty, HTTPConsumedAffordanceMixin):
 
-    def __init__(self,
-                resource: ActionAffordance,
-                connect_timeout: int = 60,
-                request_timeout: int = 60,
-                invokation_timeout: int = 5,
-                execution_timeout: int = 5,
-                **kwargs
-            ) -> None:
+class HTTPProperty(AuthHeaderMixin, ConsumedThingProperty, HTTPConsumedAffordanceMixin):
+    def __init__(
+        self,
+        resource: ActionAffordance,
+        connect_timeout: int = 60,
+        request_timeout: int = 60,
+        invokation_timeout: int = 5,
+        execution_timeout: int = 5,
+        **kwargs,
+    ) -> None:
         ConsumedThingProperty.__init__(self=self, resource=resource, **kwargs)
         HTTPConsumedAffordanceMixin.__init__(
-                        self=self,
-                        connect_timeout=connect_timeout,
-                        request_timeout=request_timeout,
-                        invokation_timeout=invokation_timeout,
-                        execution_timeout=execution_timeout,
-                        **kwargs
-                    )
+            self=self,
+            connect_timeout=connect_timeout,
+            request_timeout=request_timeout,
+            invokation_timeout=invokation_timeout,
+            execution_timeout=execution_timeout,
+            **kwargs,
+        )
         self._read_reply_op_map = dict()
-        
+
     async def set(self, value: Any) -> None:
         if self._resource.readOnly:
             raise NotImplementedError("This property is not writable")
         form = self._resource.retrieve_form(Operations.writeproperty, None)
         if form is None:
-            raise ValueError(f"No form found for writeproperty operation for {self._resource.name}")
-        serializer = Serializers.content_types.get(form.contentType or "application/json")
+            raise ValueError(
+                f"No form found for writeproperty operation for {self._resource.name}"
+            )
+        serializer = Serializers.content_types.get(
+            form.contentType or "application/json"
+        )
         body = serializer.dumps(value)
         http_request = self.create_http_request(form, "PUT", body)
         try:
             response = await self._async_http_client.fetch(http_request)
         except HTTPTimeoutError as ex:
             raise TimeoutError(str(ex)) from None
-        self.get_body_from_response(response, form) # Just to ensure the request was successful, no body expected.
+        self.get_body_from_response(
+            response, form
+        )  # Just to ensure the request was successful, no body expected.
         return None
 
     def set(self, value: Any) -> None:
@@ -217,8 +286,12 @@ class HTTPProperty(ConsumedThingProperty, HTTPConsumedAffordanceMixin):
             raise NotImplementedError("This property is not writable")
         form = self._resource.retrieve_form(Operations.writeproperty, None)
         if form is None:
-            raise ValueError(f"No form found for writeproperty operation for {self._resource.name}")
-        serializer = Serializers.content_types.get(form.contentType or "application/json")
+            raise ValueError(
+                f"No form found for writeproperty operation for {self._resource.name}"
+            )
+        serializer = Serializers.content_types.get(
+            form.contentType or "application/json"
+        )
         body = serializer.dumps(value)
         http_request = self.create_http_request(form, "PUT", body)
         try:
@@ -231,34 +304,42 @@ class HTTPProperty(ConsumedThingProperty, HTTPConsumedAffordanceMixin):
     async def get(self):
         form = self._resource.retrieve_form(Operations.readproperty, None)
         if form is None:
-            raise ValueError(f"No form found for readproperty operation for {self._resource.name}")
-        http_request = self.create_http_request(form, "GET", b'')
+            raise ValueError(
+                f"No form found for readproperty operation for {self._resource.name}"
+            )
+        http_request = self.create_http_request(form, "GET", b"")
         try:
             response = await self._async_http_client.fetch(http_request)
         except HTTPTimeoutError as ex:
             raise TimeoutError(str(ex)) from None
         return self.get_body_from_response(response, form)
-        
+
     def get(self):
         form = self._resource.retrieve_form(Operations.readproperty, None)
         if form is None:
-            raise ValueError(f"No form found for readproperty operation for {self._resource.name}")
+            raise ValueError(
+                f"No form found for readproperty operation for {self._resource.name}"
+            )
         http_request = self.create_http_request(form, "GET", None)
         try:
             response = self._sync_http_client.fetch(http_request)
         except HTTPTimeoutError as ex:
             raise TimeoutError(str(ex)) from None
         return self.get_body_from_response(response, form)
-    
+
     def oneway_set(self, value: Any) -> None:
         if self._resource.readOnly:
             raise NotImplementedError("This property is not writable")
         form = deepcopy(self._resource.retrieve_form(Operations.writeproperty, None))
         if form is None:
-            raise ValueError(f"No form found for writeproperty operation for {self._resource.name}")
-        serializer = Serializers.content_types.get(form.contentType or "application/json")
+            raise ValueError(
+                f"No form found for writeproperty operation for {self._resource.name}"
+            )
+        serializer = Serializers.content_types.get(
+            form.contentType or "application/json"
+        )
         body = serializer.dumps(value)
-        form.href = f'{form.href}?oneway=true'
+        form.href = f"{form.href}?oneway=true"
         http_request = self.create_http_request(form, "PUT", body)
         try:
             response = self._sync_http_client.fetch(http_request)
@@ -266,106 +347,137 @@ class HTTPProperty(ConsumedThingProperty, HTTPConsumedAffordanceMixin):
             raise TimeoutError(str(ex)) from None
         # we still do it like this only to ensure our logic is consistent, oneway actions do not expect a body
         return self.get_body_from_response(response, form, raise_exception=False)
-    
+
     def noblock_get(self) -> str:
         form = deepcopy(self._resource.retrieve_form(Operations.readproperty, None))
         if form is None:
-            raise ValueError(f"No form found for readproperty operation for {self._resource.name}")
-        form.href = f'{form.href}?noblock=true'
+            raise ValueError(
+                f"No form found for readproperty operation for {self._resource.name}"
+            )
+        form.href = f"{form.href}?noblock=true"
         http_request = self.create_http_request(form, "GET", None)
         try:
             response = self._sync_http_client.fetch(http_request)
         except HTTPTimeoutError as ex:
             raise TimeoutError(str(ex)) from None
-        assert response.headers.get('X-Message-ID', None) is not None, \
+        assert response.headers.get("X-Message-ID", None) is not None, (
             "The server did not return a message ID for the non-blocking property read."
-        message_id = response.headers['X-Message-ID']
-        self._read_reply_op_map[message_id] = 'readproperty'
+        )
+        message_id = response.headers["X-Message-ID"]
+        self._read_reply_op_map[message_id] = "readproperty"
         self._owner_inst._noblock_messages[message_id] = self
         return message_id
-    
+
     def noblock_set(self, value):
         form = deepcopy(self._resource.retrieve_form(Operations.writeproperty, None))
         if form is None:
-            raise ValueError(f"No form found for writeproperty operation for {self._resource.name}")
+            raise ValueError(
+                f"No form found for writeproperty operation for {self._resource.name}"
+            )
         if self._resource.readOnly:
             raise NotImplementedError("This property is not writable")
-        serializer = Serializers.content_types.get(form.contentType or "application/json")
+        serializer = Serializers.content_types.get(
+            form.contentType or "application/json"
+        )
         body = serializer.dumps(value)
-        form.href = f'{form.href}?noblock=true'
+        form.href = f"{form.href}?noblock=true"
         http_request = self.create_http_request(form, "PUT", body)
         try:
             response = self._sync_http_client.fetch(http_request)
-        except HTTPTimeoutError as ex: 
+        except HTTPTimeoutError as ex:
             raise TimeoutError(str(ex)) from None
         assert response.code == 204, "noblock did not return 204"
-        assert response.headers.get('X-Message-ID', None) is not None, \
+        assert response.headers.get("X-Message-ID", None) is not None, (
             f"The server did not return a message ID for the non-blocking property write. response headers: {response.headers}, code {response.code}"
-        message_id = response.headers['X-Message-ID']
+        )
+        message_id = response.headers["X-Message-ID"]
         self._owner_inst._noblock_messages[message_id] = self
-        self._read_reply_op_map[message_id] = 'writeproperty'
+        self._read_reply_op_map[message_id] = "writeproperty"
         return message_id
 
-    def read_reply(self, message_id, timeout = None):
-        form = deepcopy(self._resource.retrieve_form(op=self._read_reply_op_map.get(message_id, 'readproperty')))
+    def read_reply(self, message_id, timeout=None):
+        form = deepcopy(
+            self._resource.retrieve_form(
+                op=self._read_reply_op_map.get(message_id, "readproperty")
+            )
+        )
         if form is None:
-            raise ValueError(f"No form found for readproperty operation for {self._resource.name}")
+            raise ValueError(
+                f"No form found for readproperty operation for {self._resource.name}"
+            )
         return HTTPConsumedAffordanceMixin.read_reply(self, form, message_id, timeout)
-        
 
 
-class HTTPEvent(ConsumedThingEvent, HTTPConsumedAffordanceMixin):
-
-    def __init__(self, 
-                resource: EventAffordance | PropertyAffordance,
-                default_scheduling_mode: str = 'sync',
-                connect_timeout: int = 60,
-                request_timeout: int = 60,
-                invokation_timeout: int = 5,
-                execution_timeout: int = 5,
-                **kwargs
-            ) -> None:
+class HTTPEvent(AuthHeaderMixin, ConsumedThingEvent, HTTPConsumedAffordanceMixin):
+    def __init__(
+        self,
+        resource: EventAffordance | PropertyAffordance,
+        default_scheduling_mode: str = "sync",
+        connect_timeout: int = 60,
+        request_timeout: int = 60,
+        invokation_timeout: int = 5,
+        execution_timeout: int = 5,
+        **kwargs,
+    ) -> None:
         ConsumedThingEvent.__init__(self, resource=resource, **kwargs)
         HTTPConsumedAffordanceMixin.__init__(
-                            self,
-                            connect_timeout=connect_timeout,
-                            request_timeout=request_timeout,
-                            invokation_timeout=invokation_timeout,
-                            execution_timeout=execution_timeout,
-                            **kwargs
-                        )
+            self,
+            connect_timeout=connect_timeout,
+            request_timeout=request_timeout,
+            invokation_timeout=invokation_timeout,
+            execution_timeout=execution_timeout,
+            **kwargs,
+        )
         self._default_scheduling_mode = default_scheduling_mode
         self._thread = None
 
-
-    def subscribe(self, 
-                callbacks: list[Callable] | Callable, 
-                thread_callbacks: bool = False, 
-                deserialize: bool = True
-            ) -> None:
-        if not self._default_scheduling_mode in ['sync', 'async']:
-            raise ValueError(f"Invalid scheduling mode: {self._default_scheduling_mode}. Must be 'sync' or 'async'.")
-        op = Operations.observeproperty if isinstance(self._resource, PropertyAffordance) else Operations.subscribeevent
+    def subscribe(
+        self,
+        callbacks: list[Callable] | Callable,
+        thread_callbacks: bool = False,
+        deserialize: bool = True,
+    ) -> None:
+        if not self._default_scheduling_mode in ["sync", "async"]:
+            raise ValueError(
+                f"Invalid scheduling mode: {self._default_scheduling_mode}. Must be 'sync' or 'async'."
+            )
+        op = (
+            Operations.observeproperty
+            if isinstance(self._resource, PropertyAffordance)
+            else Operations.subscribeevent
+        )
         form = self._resource.retrieve_form(op, None)
         if form is None:
-            raise ValueError(f"No form found for {op} operation for {self._resource.name}")
+            raise ValueError(
+                f"No form found for {op} operation for {self._resource.name}"
+            )
         self.add_callbacks(callbacks)
         self._subscribed = True
         self._deserialize = deserialize
         self._thread_callbacks = thread_callbacks
-        if self._default_scheduling_mode == 'sync':
+        if self._default_scheduling_mode == "sync":
             self._thread = threading.Thread(target=self.listen)
             self._thread.start()
         else:
-            get_current_async_loop().call_soon(lambda: asyncio.create_task(self.async_listen()))
+            get_current_async_loop().call_soon(
+                lambda: asyncio.create_task(self.async_listen())
+            )
 
     def listen(self):
-        op = Operations.observeproperty if isinstance(self._resource, PropertyAffordance) else Operations.subscribeevent
+        op = (
+            Operations.observeproperty
+            if isinstance(self._resource, PropertyAffordance)
+            else Operations.subscribeevent
+        )
         form = self._resource.retrieve_form(op, None)
         if form is None:
-            raise ValueError(f"No form found for {op} operation for {self._resource.name}")
+            raise ValueError(
+                f"No form found for {op} operation for {self._resource.name}"
+            )
 
-        serializer = Serializers.content_types.get(form.contentType or "application/json")
+        serializer = Serializers.content_types.get(
+            form.contentType or "application/json"
+        )
         buffer = ""
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
@@ -375,11 +487,13 @@ class HTTPEvent(ConsumedThingEvent, HTTPConsumedAffordanceMixin):
             nonlocal self, serializer, buffer
 
             if not self._subscribed:
-                self._logger.debug("Unsubscribed from the event stream, stopping processing.")
+                self._logger.debug(
+                    "Unsubscribed from the event stream, stopping processing."
+                )
                 self._sync_http_client.close()
                 return
-            
-            buffer += chunk.decode('utf-8')
+
+            buffer += chunk.decode("utf-8")
             # split events on the SSE separator: two newlines
             while "\n\n" in buffer:
                 raw_event, buffer = buffer.split("\n\n", 1)
@@ -395,21 +509,21 @@ class HTTPEvent(ConsumedThingEvent, HTTPConsumedAffordanceMixin):
                         event[field] += value.lstrip()
                 if "data" in event:
                     # if the event has a data field, it is an event, and its also a string, so we need to cast it to bytes
-                    value = serializer.loads(event["data"].encode('utf-8'))
-                    for cb in self._callbacks: 
+                    value = serializer.loads(event["data"].encode("utf-8"))
+                    for cb in self._callbacks:
                         if not self._thread_callbacks:
                             cb(value)
-                        else: 
+                        else:
                             threading.Thread(target=cb, args=(value,)).start()
                 else:
                     self._logger.warning(f"Received an invalid SSE event: {raw_event}")
-            
+
         request = tornado.httpclient.HTTPRequest(
             form.href,
             method="GET",
-            headers={"Accept": "text/event-stream"},
+            headers=self._merge_auth_headers({"Accept": "text/event-stream"}),
             request_timeout=self._request_timeout,
-            connect_timeout=self._connect_timeout,  
+            connect_timeout=self._connect_timeout,
             streaming_callback=on_chunk,
         )
         try:
@@ -417,9 +531,11 @@ class HTTPEvent(ConsumedThingEvent, HTTPConsumedAffordanceMixin):
                 try:
                     response = self._sync_http_client.fetch(request, raise_error=False)
                     if response.code < 200 or response.code >= 300:
-                        raise Exception(f"Failed to subscribe to SSE stream: {response.code}")
+                        raise Exception(
+                            f"Failed to subscribe to SSE stream: {response.code}"
+                        )
                 except HTTPTimeoutError as ex:
-                    pass 
+                    pass
         except HTTPStreamClosedError as ex:
             self._logger.debug(f"HTTP stream closed: {str(ex)}")
         finally:
@@ -427,21 +543,17 @@ class HTTPEvent(ConsumedThingEvent, HTTPConsumedAffordanceMixin):
             for task in tasks:
                 task.cancel()
             loop.close()
-            self._sync_http_client.close() # can close twice sometimes, seems to be OK
-            
+            self._sync_http_client.close()  # can close twice sometimes, seems to be OK
+
     def unsubscribe(self, join_thread: bool = True):
         """
-        Unsubscribe from the event. 
+        Unsubscribe from the event.
         Its inherently a little slower due to the nature of HTTP, please wait until the request timeout is reached.
         """
         self._subscribed = False
         if self._thread and join_thread:
             self._thread.join()
             self._thread = None
-  
 
-__all__ = [
-    HTTPProperty.__name__,
-    HTTPAction.__name__,
-    HTTPEvent.__name__
-]
+
+__all__ = [HTTPProperty.__name__, HTTPAction.__name__, HTTPEvent.__name__]

--- a/hololinked/client/proxy.py
+++ b/hololinked/client/proxy.py
@@ -1,36 +1,36 @@
-import typing 
+import typing
 import logging
+import base64
 
 from .abstractions import ConsumedThingAction, ConsumedThingProperty, ConsumedThingEvent
 from .factory import ClientFactory
 
 
-
 class ObjectProxy:
     """
-    Procedural client for ``Thing``/``RemoteObject``. Once connected to a server, properties, methods and events are 
-    dynamically populated. Any of the ZMQ protocols of the server is supported. 
+    Procedural client for ``Thing``/``RemoteObject``. Once connected to a server, properties, methods and events are
+    dynamically populated. Any of the ZMQ protocols of the server is supported.
 
     Parameters
     ----------
     id: str
         instance name of the server to connect.
     invokation_timeout: float, int
-        timeout to schedule a method call or property read/write in server. execution time wait is controlled by 
-        ``execution_timeout``. When invokation timeout expires, the method is not executed. 
+        timeout to schedule a method call or property read/write in server. execution time wait is controlled by
+        ``execution_timeout``. When invokation timeout expires, the method is not executed.
     execution_timeout: float, int
         timeout to return without a reply after scheduling a method call or property read/write. This timer starts
-        ticking only after the method has started to execute. Returning a call before end of execution can lead to 
-        change of state in the server. 
+        ticking only after the method has started to execute. Returning a call before end of execution can lead to
+        change of state in the server.
     load_thing: bool, default True
         when True, remote object is located and its resources are loaded. Otherwise, only the client is initialised.
     protocol: str
-        ZMQ protocol used to connect to server. Unlike the server, only one can be specified.  
-    **kwargs: 
+        ZMQ protocol used to connect to server. Unlike the server, only one can be specified.
+    **kwargs:
         async_mixin: bool, default False
-            whether to use both synchronous and asynchronous clients. 
+            whether to use both synchronous and asynchronous clients.
         serializer: BaseSerializer
-            use a custom serializer, must be same as the serializer supplied to the server. 
+            use a custom serializer, must be same as the serializer supplied to the server.
         schema_validator: BaseSchemaValidator
             use a schema validator, must be same as the schema validator supplied to the server.
         allow_foreign_attributes: bool, default False
@@ -43,35 +43,48 @@ class ObjectProxy:
             time in milliseconds to search & handshake server remote object. raises Timeout when expired
     """
 
-    _own_attrs = frozenset([
-        '__annotations__',
-        '_allow_foreign_attributes',
-        'id', 'logger', 'td', 
-        'execution_timeout', 'invokation_timeout', '_execution_timeout', '_invokation_timeout', 
-        '_events', 
-        '_noblock_messages',
-        '_schema_validator'
-    ])
+    _own_attrs = frozenset(
+        [
+            "__annotations__",
+            "_allow_foreign_attributes",
+            "id",
+            "logger",
+            "td",
+            "execution_timeout",
+            "invokation_timeout",
+            "_execution_timeout",
+            "_invokation_timeout",
+            "_events",
+            "_noblock_messages",
+            "_schema_validator",
+            "_auth_header",
+        ]
+    )
 
-    def __init__(self, 
-                id: str, 
-                **kwargs
-            ) -> None:
-        self._allow_foreign_attributes = kwargs.get('allow_foreign_attributes', False)
-        self._noblock_messages = dict() # type: typing.Dict[str, ConsumedThingAction | ConsumedThingProperty]
-        self._schema_validator = kwargs.get('schema_validator', None)
+    def __init__(self, id: str, **kwargs) -> None:
+        self._allow_foreign_attributes = kwargs.get("allow_foreign_attributes", False)
+        self._noblock_messages = dict()  # type: typing.Dict[str, ConsumedThingAction | ConsumedThingProperty]
+        self._schema_validator = kwargs.get("schema_validator", None)
         self.id = id
         self.logger = kwargs.pop(
-                            'logger', 
-                            logging.Logger(self.id, level=kwargs.get('log_level', logging.INFO))
-                        )
+            "logger",
+            logging.Logger(self.id, level=kwargs.get("log_level", logging.INFO)),
+        )
         self.invokation_timeout = kwargs.get("invokation_timeout", 5)
         self.execution_timeout = kwargs.get("execution_timeout", 5)
-        self.td = kwargs.get('td', dict()) # type: typing.Dict[str, typing.Any]
+        self.td = kwargs.get("td", dict())  # type: typing.Dict[str, typing.Any]
         # compose ZMQ client in Proxy client so that all sending and receiving is
-        # done by the ZMQ client and not by the Proxy client directly. Proxy client only 
+        # done by the ZMQ client and not by the Proxy client directly. Proxy client only
         # bothers mainly about __setattr__ and _getattr__
         # ClientFactory.zmq(self, **kwargs)
+        self._auth_header = None
+        username = kwargs.get("username")
+        password = kwargs.get("password")
+        if username and password:
+            token = f"{username}:{password}".encode("utf-8")
+            self._auth_header = {
+                "Authorization": f"Basic {base64.b64encode(token).decode('utf-8')}"
+            }
 
     def __getattribute__(self, __name: str) -> typing.Any:
         obj = super().__getattribute__(__name)
@@ -79,9 +92,15 @@ class ObjectProxy:
             return obj.get()
         return obj
 
-    def __setattr__(self, __name : str, __value : typing.Any) -> None:
-        if (__name in ObjectProxy._own_attrs or (__name not in self.__dict__ and 
-                isinstance(__value, ClientFactory.__allowed_attribute_types__)) or self._allow_foreign_attributes):
+    def __setattr__(self, __name: str, __value: typing.Any) -> None:
+        if (
+            __name in ObjectProxy._own_attrs
+            or (
+                __name not in self.__dict__
+                and isinstance(__value, ClientFactory.__allowed_attribute_types__)
+            )
+            or self._allow_foreign_attributes
+        ):
             # allowed attribute types are ConsumedThingProperty and ConsumedThingAction defined after this class
             return super(ObjectProxy, self).__setattr__(__name, __value)
         elif __name in self.__dict__:
@@ -89,11 +108,15 @@ class ObjectProxy:
             if isinstance(obj, ConsumedThingProperty):
                 obj.set(value=__value)
                 return
-            raise AttributeError(f"Cannot set attribute {__name} again to ObjectProxy for {self.id}.")
-        raise AttributeError(f"Cannot set foreign attribute {__name} to ObjectProxy for {self.id}. Given attribute not found in server object.")
+            raise AttributeError(
+                f"Cannot set attribute {__name} again to ObjectProxy for {self.id}."
+            )
+        raise AttributeError(
+            f"Cannot set foreign attribute {__name} to ObjectProxy for {self.id}. Given attribute not found in server object."
+        )
 
     def __repr__(self) -> str:
-        return f'ObjectProxy {self.id}'
+        return f"ObjectProxy {self.id}"
 
     def __enter__(self):
         return self
@@ -101,9 +124,11 @@ class ObjectProxy:
     def __exit__(self, exc_type, exc_value, traceback):
         pass
 
-    def __bool__(self) -> bool: 
-        raise NotImplementedError("Cannot convert ObjectProxy to bool. Use is_connected() instead.")
-        # try: 
+    def __bool__(self) -> bool:
+        raise NotImplementedError(
+            "Cannot convert ObjectProxy to bool. Use is_connected() instead."
+        )
+        # try:
         #     self.zmq_client.handshake(num_of_tries=10)
         #     return True
         # except RuntimeError:
@@ -112,47 +137,60 @@ class ObjectProxy:
     def __eq__(self, other) -> bool:
         if other is self:
             return True
-        return (isinstance(other, ObjectProxy) and other.id == self.id and 
-                other.zmq_client.protocol == self.zmq_client.protocol)
+        return (
+            isinstance(other, ObjectProxy)
+            and other.id == self.id
+            and other.zmq_client.protocol == self.zmq_client.protocol
+        )
 
     def __ne__(self, other) -> bool:
         if other and isinstance(other, ObjectProxy):
-            return (other.id != self.id or 
-                    other.zmq_client.protocol != self.zmq_client.protocol)
+            return (
+                other.id != self.id
+                or other.zmq_client.protocol != self.zmq_client.protocol
+            )
         return True
 
     def __hash__(self) -> int:
         return hash(self.id)
-    
+
     def get_invokation_timeout(self) -> typing.Union[float, int]:
-        return self._invokation_timeout 
-    
-    def set_invokation_timeout(self, value : typing.Union[float, int]) -> None:
+        return self._invokation_timeout
+
+    def set_invokation_timeout(self, value: typing.Union[float, int]) -> None:
         if not isinstance(value, (float, int, type(None))):
-            raise TypeError(f"Timeout can only be float or int greater than 0, or None. Given type {type(value)}.")
+            raise TypeError(
+                f"Timeout can only be float or int greater than 0, or None. Given type {type(value)}."
+            )
         elif value is not None and value < 0:
             raise ValueError("Timeout must be at least 0 or None, not negative.")
         self._invokation_timeout = value
-    
-    invokation_timeout = property(fget=get_invokation_timeout, fset=set_invokation_timeout,
-                        doc="Timeout in seconds on server side for invoking a method or read/write property. \
-                                Defaults to 5 seconds and network times not considered."
+
+    invokation_timeout = property(
+        fget=get_invokation_timeout,
+        fset=set_invokation_timeout,
+        doc="Timeout in seconds on server side for invoking a method or read/write property. \
+                                Defaults to 5 seconds and network times not considered.",
     )
 
     def get_execution_timeout(self) -> typing.Union[float, int]:
-        return self._execution_timeout 
-    
-    def set_execution_timeout(self, value : typing.Union[float, int]) -> None:
+        return self._execution_timeout
+
+    def set_execution_timeout(self, value: typing.Union[float, int]) -> None:
         if not isinstance(value, (float, int, type(None))):
-            raise TypeError(f"Timeout can only be float or int greater than 0, or None. Given type {type(value)}.")
+            raise TypeError(
+                f"Timeout can only be float or int greater than 0, or None. Given type {type(value)}."
+            )
         elif value is not None and value < 0:
             raise ValueError("Timeout must be at least 0 or None, not negative.")
         self._execution_timeout = value
-    
-    execution_timeout = property(fget=get_execution_timeout, fset=set_execution_timeout,
-                            doc="Timeout in seconds on server side for execution of method or read/write property." +
-                                "Starts ticking after invokation timeout completes." + 
-                                "Defaults to None (i.e. waits indefinitely until return) and network times not considered."
+
+    execution_timeout = property(
+        fget=get_execution_timeout,
+        fset=set_execution_timeout,
+        doc="Timeout in seconds on server side for execution of method or read/write property."
+        + "Starts ticking after invokation timeout completes."
+        + "Defaults to None (i.e. waits indefinitely until return) and network times not considered.",
     )
 
     # @abstractmethod
@@ -161,46 +199,42 @@ class ObjectProxy:
     #     with the given name is supported in this Protocol Binding client."""
     #     raise NotImplementedError()
 
-   
-    def invoke_action(
-                    self, 
-                    name: str, 
-                    *args, 
-                    **kwargs
-                ) -> typing.Any:
+    def invoke_action(self, name: str, *args, **kwargs) -> typing.Any:
         """
         call a method specified by name on the server with positional/keyword arguments
 
         Parameters
         ----------
-        method: str 
+        method: str
             name of the method
-        oneway: bool, default False 
+        oneway: bool, default False
             only send an instruction to invoke the method but do not fetch the reply.
-        noblock: bool, default False 
+        noblock: bool, default False
             request a method call but collect the reply later using a reply id
         *args: Any
-            arguments for the method 
+            arguments for the method
         **kwargs: Dict[str, Any]
             keyword arguments for the method
 
         Returns
         -------
-        Any 
-            return value of the method call or an id if noblock is True 
+        Any
+            return value of the method call or an id if noblock is True
 
         Raises
         ------
-        AttributeError: 
+        AttributeError:
             if no method with specified name found on the server
         Exception:
-            server raised exception are propagated 
+            server raised exception are propagated
         """
-        method = getattr(self, name, None) # type: ConsumedThingAction 
+        method = getattr(self, name, None)  # type: ConsumedThingAction
         if not isinstance(method, ConsumedThingAction):
-            raise AttributeError(f"No remote method named {name} in Thing {self.td['id']}")
-        oneway = kwargs.pop('oneway', False)
-        noblock = kwargs.pop('noblock', False)
+            raise AttributeError(
+                f"No remote method named {name} in Thing {self.td['id']}"
+            )
+        oneway = kwargs.pop("oneway", False)
+        noblock = kwargs.pop("noblock", False)
         if noblock:
             return method.noblock(*args, **kwargs)
         elif oneway:
@@ -208,65 +242,58 @@ class ObjectProxy:
         else:
             return method(*args, **kwargs)
 
-
-    async def async_invoke_action(
-                                self, 
-                                name: str, 
-                                *args, 
-                                **kwargs
-                            ) -> typing.Any:
+    async def async_invoke_action(self, name: str, *args, **kwargs) -> typing.Any:
         """
-        async(io) call a method specified by name on the server with positional/keyword 
-        arguments. noblock and oneway not supported for async calls. 
+        async(io) call a method specified by name on the server with positional/keyword
+        arguments. noblock and oneway not supported for async calls.
 
         Parameters
         ----------
-        method: str 
+        method: str
             name of the method
         *args: Any
-            arguments for the method 
+            arguments for the method
         **kwargs: Dict[str, Any]
             keyword arguments for the method
 
         Returns
         -------
-        Any 
+        Any
             return value of the method call
-        
+
         Raises
         ------
-        AttributeError: 
+        AttributeError:
             if no method with specified name found on the server
         RuntimeError:
             if async_mixin was False at ``__init__()`` - no asynchronous client was created
         Exception:
             server raised exception are propagated
         """
-        method = getattr(self, name, None) # type: ConsumedThingAction 
+        method = getattr(self, name, None)  # type: ConsumedThingAction
         if not isinstance(method, ConsumedThingAction):
             raise AttributeError(f"No remote method named {name}")
         return await method.async_call(*args, **kwargs)
 
-
     def read_property(self, name: str, noblock: bool = False) -> typing.Any:
         """
-        get property specified by name on server. 
+        get property specified by name on server.
 
         Parameters
         ----------
-        name: str 
+        name: str
             name of the property
-        noblock: bool, default False 
+        noblock: bool, default False
             request the property get but collect the reply/value later using a reply id
 
         Raises
         ------
-        AttributeError: 
+        AttributeError:
             if no method with specified name found on the server
         Exception:
             server raised exception are propagated
         """
-        prop = self.__dict__.get(name, None) # type: ConsumedThingProperty
+        prop = self.__dict__.get(name, None)  # type: ConsumedThingProperty
         if not isinstance(prop, ConsumedThingProperty):
             raise AttributeError(f"No property named {name}")
         if noblock:
@@ -274,37 +301,32 @@ class ObjectProxy:
         else:
             return prop.get()
 
-
     def write_property(
-                    self, 
-                    name: str, 
-                    value: typing.Any, 
-                    oneway: bool = False, 
-                    noblock: bool = False
-                ) -> None:
+        self, name: str, value: typing.Any, oneway: bool = False, noblock: bool = False
+    ) -> None:
         """
-        set property specified by name on server with specified value. 
+        set property specified by name on server with specified value.
 
         Parameters
         ----------
         name: str
             name of the property
-        value: Any 
+        value: Any
             value of property to be set
-        oneway: bool, default False 
+        oneway: bool, default False
             only send an instruction to set the property but do not fetch the reply.
             (irrespective of whether set was successful or not)
-        noblock: bool, default False 
+        noblock: bool, default False
             request the set property but collect the reply later using a reply id
 
         Raises
         ------
-        AttributeError: 
+        AttributeError:
             if no method with specified name found on the server
         Exception:
             server raised exception are propagated
         """
-        prop = self.__dict__.get(name, None) # type: ConsumedThingProperty
+        prop = self.__dict__.get(name, None)  # type: ConsumedThingProperty
         if not isinstance(prop, ConsumedThingProperty):
             raise AttributeError(f"No property named {name}")
         if oneway:
@@ -314,63 +336,62 @@ class ObjectProxy:
         else:
             prop.set(value)
 
-
     async def async_read_property(self, name: str) -> None:
         """
-        async(io) get property specified by name on server. 
+        async(io) get property specified by name on server.
 
         Parameters
         ----------
-        name: Any 
-            name of the property to fetch 
+        name: Any
+            name of the property to fetch
 
         Raises
         ------
-        AttributeError: 
+        AttributeError:
             if no method with specified name found on the server
         Exception:
             server raised exception are propagated
         """
-        prop = self.__dict__.get(name, None) # type: ConsumedThingProperty
+        prop = self.__dict__.get(name, None)  # type: ConsumedThingProperty
         if not isinstance(prop, ConsumedThingProperty):
             raise AttributeError(f"No property named {name}")
         return await prop.async_get()
-    
 
     async def async_write_property(self, name: str, value: typing.Any) -> None:
         """
-        async(io) set property specified by name on server with specified value.  
-        noblock and oneway not supported for async calls. 
+        async(io) set property specified by name on server with specified value.
+        noblock and oneway not supported for async calls.
 
         Parameters
         ----------
-        name: str 
+        name: str
             name of the property
-        value: Any 
+        value: Any
             value of property to be set
-        
+
         Raises
         ------
-        AttributeError: 
+        AttributeError:
             if no method with specified name found on the server
         Exception:
             server raised exception are propagated
         """
-        prop = self.__dict__.get(name, None) # type: ConsumedThingProperty
+        prop = self.__dict__.get(name, None)  # type: ConsumedThingProperty
         if not isinstance(prop, ConsumedThingProperty):
             raise AttributeError(f"No property named {name}")
         await prop.async_set(value)
 
-
-    def read_multiple_properties(self, names: typing.List[str], noblock: bool = False) -> typing.Any:
+    def read_multiple_properties(
+        self, names: typing.List[str], noblock: bool = False
+    ) -> typing.Any:
         """
         get properties specified by list of names.
 
         Parameters
         ----------
         names: List[str]
-            names of properties to be fetched 
-        noblock: bool, default False 
+            names of properties to be fetched
+        noblock: bool, default False
             request the fetch but collect the reply later using a reply id
 
         Returns
@@ -378,53 +399,55 @@ class ObjectProxy:
         Dict[str, Any]:
             dictionary with names as keys and values corresponding to those keys
         """
-        method = getattr(self, '_get_properties', None) # type: ConsumedThingAction
+        method = getattr(self, "_get_properties", None)  # type: ConsumedThingAction
         if not method:
-            raise RuntimeError("Client did not load server resources correctly. Report issue at github.")
+            raise RuntimeError(
+                "Client did not load server resources correctly. Report issue at github."
+            )
         if noblock:
             return method.noblock(names=names)
         else:
             return method(names=names)
-        
-    
+
     def write_multiple_properties(
-                                self, 
-                                oneway: bool = False, 
-                                noblock: bool = False,
-                                **properties : typing.Dict[str, typing.Any]
-                            ) -> None:
+        self,
+        oneway: bool = False,
+        noblock: bool = False,
+        **properties: typing.Dict[str, typing.Any],
+    ) -> None:
         """
         set properties whose name is specified by keys of a dictionary
 
         Parameters
         ----------
-        oneway: bool, default False 
+        oneway: bool, default False
             only send an instruction to set the property but do not fetch the reply.
             (irrespective of whether set was successful or not)
-        noblock: bool, default False 
+        noblock: bool, default False
             request the set property but collect the reply later using a reply id
         **properties: Dict[str, Any]
             name and value of properties to be set
 
         Raises
         ------
-        AttributeError: 
+        AttributeError:
             if no method with specified name found on the server
         Exception:
             server raised exception are propagated
         """
         if len(properties) == 0:
             raise ValueError("no properties given to set_properties")
-        method = getattr(self, '_set_properties', None) # type: ConsumedThingAction
+        method = getattr(self, "_set_properties", None)  # type: ConsumedThingAction
         if not method:
-            raise RuntimeError("Client did not load server resources correctly. Report issue at github.")
+            raise RuntimeError(
+                "Client did not load server resources correctly. Report issue at github."
+            )
         if oneway:
             method.oneway(**properties)
         elif noblock:
             return method.noblock(**properties)
         else:
             return method(**properties)
-        
 
     async def async_read_multiple_properties(self, names: typing.List[str]) -> None:
         """
@@ -433,174 +456,187 @@ class ObjectProxy:
         Parameters
         ----------
         names: List[str]
-            names of properties to be fetched 
- 
+            names of properties to be fetched
+
         Returns
         -------
         Dict[str, Any]:
             dictionary with property names as keys and values corresponding to those keys
         """
-        method = getattr(self, '_get_properties', None) # type: ConsumedThingAction
+        method = getattr(self, "_get_properties", None)  # type: ConsumedThingAction
         if not method:
-            raise RuntimeError("Client did not load server resources correctly. Report issue at github.")
+            raise RuntimeError(
+                "Client did not load server resources correctly. Report issue at github."
+            )
         return await method.async_call(names=names)
 
-
-    async def async_write_multiple_properties(self, **properties: dict[str, typing.Any]) -> None:
+    async def async_write_multiple_properties(
+        self, **properties: dict[str, typing.Any]
+    ) -> None:
         """
         async(io) set properties whose name is specified by keys of a dictionary
 
         Parameters
         ----------
-        values: Dict[str, Any] 
+        values: Dict[str, Any]
             name and value of properties to be set
-       
+
         Raises
         ------
-        AttributeError: 
+        AttributeError:
             if no method with specified name found on the server
         Exception:
             server raised exception are propagated
         """
         if len(properties) == 0:
             raise ValueError("no properties given to set_properties")
-        method = getattr(self, '_set_properties', None) # type: ConsumedThingAction
+        method = getattr(self, "_set_properties", None)  # type: ConsumedThingAction
         if not method:
-            raise RuntimeError("Client did not load server resources correctly. Report issue at github.")
+            raise RuntimeError(
+                "Client did not load server resources correctly. Report issue at github."
+            )
         await method.async_call(**properties)
 
-
     def observe_property(
-                    self,
-                    name: str,
-                    callbacks: typing.Union[typing.List[typing.Callable], typing.Callable],
-                    thread_callbacks: bool = False,
-                    deserialize: bool = True
-                ) -> None:
-        event = getattr(self, f"{name}_change_event", None) # type: ConsumedThingEvent
+        self,
+        name: str,
+        callbacks: typing.Union[typing.List[typing.Callable], typing.Callable],
+        thread_callbacks: bool = False,
+        deserialize: bool = True,
+    ) -> None:
+        event = getattr(self, f"{name}_change_event", None)  # type: ConsumedThingEvent
         if not isinstance(event, ConsumedThingEvent):
             raise AttributeError(f"No events for property {name}")
         self.subscribe_event(
             name=f"{name}_change_event",
             callbacks=callbacks,
             thread_callbacks=thread_callbacks,
-            deserialize=deserialize
+            deserialize=deserialize,
         )
-
 
     def unobserve_property(self, name: str) -> None:
         """
-        Unsubscribe to property specified by name. 
+        Unsubscribe to property specified by name.
 
         Parameters
         ----------
         name: str
-            name of the property 
+            name of the property
         callbacks: Callable | List[Callable]
             one or more callbacks that will be executed
         thread_callbacks: bool
             thread the callbacks otherwise the callbacks will be executed serially
-        """ 
-        event = getattr(self, f"{name}_change_event", None) # type: ConsumedThingEvent
+        """
+        event = getattr(self, f"{name}_change_event", None)  # type: ConsumedThingEvent
         if not isinstance(event, ConsumedThingEvent):
             raise AttributeError(f"No events for property {name}")
         event.unsubscribe()
-        
 
     def subscribe_event(
-                    self, 
-                    name: str, 
-                    callbacks: typing.Union[typing.List[typing.Callable], typing.Callable],
-                    thread_callbacks: bool = False, 
-                    deserialize: bool = True
-                ) -> None:
+        self,
+        name: str,
+        callbacks: typing.Union[typing.List[typing.Callable], typing.Callable],
+        thread_callbacks: bool = False,
+        deserialize: bool = True,
+    ) -> None:
         """
         Subscribe to event specified by name. Events are listened in separate threads and supplied callbacks are
-        are also called in those threads. 
+        are also called in those threads.
 
         Parameters
         ----------
         name: str
             name of the event, either the object name used in the server or the name specified in the name argument of
-            the Event object 
+            the Event object
         callbacks: Callable | List[Callable]
             one or more callbacks that will be executed when this event is received
         thread_callbacks: bool
             thread the callbacks otherwise the callbacks will be executed serially
-        
+
         Raises
         ------
-        AttributeError: 
+        AttributeError:
             if no event with specified name is found
         """
-        event = getattr(self, name, None) # type: ConsumedThingEvent
+        event = getattr(self, name, None)  # type: ConsumedThingEvent
         if not isinstance(event, ConsumedThingEvent):
             raise AttributeError(f"No event named {name}")
         event._deserialize = deserialize
         if event._subscribed:
             event.add_callbacks(callbacks)
-        else: 
+        else:
             event.subscribe(callbacks, thread_callbacks, deserialize)
-       
 
     def unsubscribe_event(self, name: str):
         """
-        Unsubscribe to event specified by name. 
+        Unsubscribe to event specified by name.
 
         Parameters
         ----------
         name: str
-            name of the event 
-                    
+            name of the event
+
         Raises
         ------
-        AttributeError: 
+        AttributeError:
             if no event with specified name is found
         """
-        event = getattr(self, name, None) # type: ConsumedThingEvent
+        event = getattr(self, name, None)  # type: ConsumedThingEvent
         if not isinstance(event, ConsumedThingEvent):
             raise AttributeError(f"No event named {name}")
         event.unsubscribe()
 
-    
-    def read_reply(self, message_id: str, timeout: typing.Optional[float] = 5000) -> typing.Any:
+    def read_reply(
+        self, message_id: str, timeout: typing.Optional[float] = 5000
+    ) -> typing.Any:
         """
         read reply of no block calls of an action or a property read/write.
         """
-        obj = self._noblock_messages.get(message_id, None) 
+        obj = self._noblock_messages.get(message_id, None)
         if not obj:
-            raise ValueError('given message id not a one way call or invalid.')
+            raise ValueError("given message id not a one way call or invalid.")
         return obj.read_reply(message_id=message_id, timeout=timeout)
-        
-        
+
     @property
     def properties(self) -> typing.List[ConsumedThingProperty]:
         """
         list of properties in the server object
         """
-        return [prop for prop in self.__dict__.values() if isinstance(prop, ConsumedThingProperty)]
-    
+        return [
+            prop
+            for prop in self.__dict__.values()
+            if isinstance(prop, ConsumedThingProperty)
+        ]
+
     @property
     def actions(self) -> typing.List[ConsumedThingAction]:
         """
         list of actions in the server object
         """
-        return [action for action in self.__dict__.values() if isinstance(action, ConsumedThingAction)]
+        return [
+            action
+            for action in self.__dict__.values()
+            if isinstance(action, ConsumedThingAction)
+        ]
 
     @property
     def events(self) -> typing.List[ConsumedThingEvent]:
         """
         list of events in the server object
         """
-        return [event for event in self.__dict__.values() if isinstance(event, ConsumedThingEvent)]
-    
+        return [
+            event
+            for event in self.__dict__.values()
+            if isinstance(event, ConsumedThingEvent)
+        ]
+
     @property
     def thing_id(self) -> str:
         """
         id of the server object
         """
         return self.td.get("id", None)
-    
+
     @property
     def TD(self) -> typing.Dict[str, typing.Any]:
         """
@@ -609,7 +645,4 @@ class ObjectProxy:
         return self.td
 
 
-__all__ = [
-    ObjectProxy.__name__
-]
-
+__all__ = [ObjectProxy.__name__]

--- a/run_testthing_basic.py
+++ b/run_testthing_basic.py
@@ -1,0 +1,17 @@
+# run_testthing_basic.py
+import logging, time, uuid
+from tests.things.test_thing import TestThing
+from hololinked.server.security import BcryptBasicSecurity
+
+thing_id = f"tt-{uuid.uuid4().hex[:6]}"
+port = 60110
+sec = BcryptBasicSecurity(username="cliuser", password="clipass")
+
+thing = TestThing(id=thing_id, log_level=logging.INFO)
+thing.run_with_http_server(
+    forked=True, port=port, config={"allow_cors": True}, security_schemes=[sec]
+)
+
+print(f"TD: http://127.0.0.1:{port}/{thing_id}/resources/wot-td")
+print(f"Prop: http://127.0.0.1:{port}/{thing_id}/base-property")
+while True: time.sleep(5)

--- a/uv.lock
+++ b/uv.lock
@@ -485,7 +485,7 @@ requires-dist = [
     { name = "pyzmq", specifier = ">=25.1.0,<26.2" },
     { name = "sqlalchemy", specifier = ">2.0.21" },
     { name = "sqlalchemy-utils", specifier = "==0.41.1" },
-    { name = "tornado", specifier = "==6.5.1" },
+    { name = "tornado", specifier = ">=6.3.3" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## ✅ Checklist from the issue

* [x] **Server:** define method to add security metadata in `ThingDescriptionHandler`
  Implemented as `add_security_definitions(...)` (following existing naming in the codebase). It inspects `server.security_schemes` and injects TD fields accordingly.
* [x] **TD metadata:** add `securityDefinitions` and `security` to TD

  * Emits entries like:

    ```json
    "securityDefinitions": {
      "basic_sc_0": { "scheme": "basic", "in": "header" }
    },
    "security": ["basic_sc_0"]
    ```
  * Supports multiple schemes; falls back to `"nosec"` when none configured.
* [x] **Client:** support on HTTP `ObjectProxy` and send default auth header on every request

  * `ClientFactory.http(..., username=..., password=...)` now sets an internal **Basic** header.
  * All HTTP interactions (actions/properties/events) merge this header via a shared helper.
* [] **Tests + Docs:(not yet will do if everything is right) **

  * Added/updated tests under `tests/test_13_protocols_http.py` (notably: `test_12_object_proxy_with_basic_auth`).
  * Added README section (below) showing how to try locally with quick commands.


